### PR TITLE
[WIP] Tentitive bug fix

### DIFF
--- a/server/src/main/java/bio/knowledge/server/blackboard/AbstractQuery.java
+++ b/server/src/main/java/bio/knowledge/server/blackboard/AbstractQuery.java
@@ -27,6 +27,7 @@
  */
 package bio.knowledge.server.blackboard;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -134,9 +135,11 @@ public abstract class AbstractQuery<
 	 */
 	@Override
 	public List<Integer> getQueryBeacons() {
-		if(nullOrEmpty(queryBeacons))
+		if(nullOrEmpty(queryBeacons)) {
 			queryBeacons = beaconHarvestService.getAllBeacons();
-		return queryBeacons;
+		}
+		
+		return new ArrayList<>(queryBeacons);
 	}
 	
 	private QueryTracker tracker = null;


### PR DESCRIPTION
This fixes a concurrency bug wherein the `beacons` list is being modified (on another thread, it seems) while being iterated through. This bug is why nDex often times disappears from the list of beacon statuses, when it times out. With this PR instead the nDex beacon reports an error status code, instead of disappearing from the status list.

I consider this a tentitive fix because while it prevents the problematic behavior, the underlying design flaw still exists.