### PR TITLE
Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+configure:
+	cp -f server/src/main/resources/application.properties-template server/src/main/resources/application.properties
+	cp -f server/src/main/resources/ogm.properties-template server/src/main/resources/ogm.properties

--- a/aggregator/src/main/java/bio/knowledge/aggregator/ApiClient.java
+++ b/aggregator/src/main/java/bio/knowledge/aggregator/ApiClient.java
@@ -29,6 +29,7 @@
 package bio.knowledge.aggregator;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +55,21 @@ public class ApiClient extends bio.knowledge.client.ApiClient {
 		super();
 		setBasePath(basePath);
 		this.beaconId = beaconId;
+		
+		super.getHttpClient().setReadTimeout(20, TimeUnit.SECONDS);
+	}
+	
+	public ApiClient() {
+		super();
+		
+		super.getHttpClient().setReadTimeout(20, TimeUnit.SECONDS);
+	}
+
+	@Override
+	public ApiClient setConnectTimeout(int connectionTimeout) {
+		getHttpClient().setConnectTimeout(connectionTimeout, TimeUnit.MILLISECONDS);
+		getHttpClient().setReadTimeout(connectionTimeout, TimeUnit.MILLISECONDS);
+		return this;
 	}
 
 	@Override

--- a/aggregator/src/main/java/bio/knowledge/aggregator/KnowledgeBeaconService.java
+++ b/aggregator/src/main/java/bio/knowledge/aggregator/KnowledgeBeaconService.java
@@ -940,9 +940,7 @@ public class KnowledgeBeaconService implements Util, SystemTimeOut {
 					categories,
 					size
 			);
-			
-			statementsApi.getStatements(sourceConceptIds, edgeLabel, relation, targetConceptIds, keywords, categories, size);
-			
+
 		} catch (ApiException e) {
 			throw new RuntimeException(e);
 		}

--- a/aggregator/src/main/java/bio/knowledge/aggregator/QuerySession.java
+++ b/aggregator/src/main/java/bio/knowledge/aggregator/QuerySession.java
@@ -7,6 +7,8 @@ import java.util.concurrent.CompletableFuture;
 import bio.knowledge.model.aggregator.QueryTracker;
 
 public interface QuerySession<Q> {
+	
+	public void clearBeaconCall(Integer beaconId);
 
 	/**
 	 * 
@@ -33,15 +35,6 @@ public interface QuerySession<Q> {
 	 */
 	public List<Integer> getQueryBeacons();
 	
-	/**
-	 * 
-	 * @return
-	 */
-	public Map<
-		Integer,
-		CompletableFuture<Integer>
-	> getBeaconCallMap();
-
 	/**
 	 * 
 	 * @param tracker

--- a/database/src/main/java/bio/knowledge/database/repository/StatementRepository.java
+++ b/database/src/main/java/bio/knowledge/database/repository/StatementRepository.java
@@ -88,14 +88,14 @@ public interface StatementRepository extends Neo4jRepository<Neo4jStatement,Long
 	
 	@Query(
 	" MATCH " +
-	" 	path1=(q:QueryTracker)-[:QUERY]->(s:Statement)-[:BEACON_CITATION]->(c:BeaconCitation)-[:SOURCE_BEACON]->(b:KnowledgeBeacon) " +
+	" 	path1=(q:QueryTracker {queryString: {queryString}})-[:QUERY]->(s:Statement)-[:BEACON_CITATION]->(c:BeaconCitation)-[:SOURCE_BEACON]->(b:KnowledgeBeacon) " +
 	" MATCH " + 
-	" 	path2=(subject:Concept)<-[:SUBJECT]-(s)-[:OBJECT]->(object:Concept), " +
-	" 	path3=(s)-[:RELATION]->(r:Predicate), " +
-	" 	path4=(subjectClique:ConceptClique)<-[:MEMBER_OF]-(subject)-[:BEACON_CITATION]->(subjectCitation:BeaconCitation)-[:SOURCE_BEACON]->(subjectBeacon:KnowledgeBeacon), " +
-	"	path5=(objectClique:ConceptClique)<-[:MEMBER_OF]-(object)-[:BEACON_CITATION]->(objectCitation:BeaconCitation)-[:SOURCE_BEACON]->(objectBeacon:KnowledgeBeacon) " + 
-	" WHERE q.queryString = {queryString} " +
-	" RETURN path1, path2, path3, path4, path5 " +
+	" 	path2=(subjectClique:ConceptClique)<-[:MEMBER_OF]-(subject:Concept)<-[:SUBJECT]-(s)-[:OBJECT]->(object:Concept)-[:MEMBER_OF]->(objectClique:ConceptClique), " +
+	" 	path3=(s)-[:RELATION]->(r:Predicate) " +
+//	" 	path4=(subjectClique:ConceptClique)<-[:MEMBER_OF]-(subject)-[:BEACON_CITATION]->(subjectCitation:BeaconCitation)-[:SOURCE_BEACON]->(subjectBeacon:KnowledgeBeacon), " +
+//	"	path5=(objectClique:ConceptClique)<-[:MEMBER_OF]-(object)-[:BEACON_CITATION]->(objectCitation:BeaconCitation)-[:SOURCE_BEACON]->(objectBeacon:KnowledgeBeacon) " + 
+	" WHERE {beaconIds} IS NULL OR ANY(id IN {beaconIds} WHERE id = b.beaconId) " +
+	" RETURN path1, path2, path3 " +
 	" LIMIT {pageSize} "
 	)
 	public List<Neo4jStatement> getQueryResults(

--- a/server/src/main/java/bio/knowledge/server/blackboard/BeaconCall.java
+++ b/server/src/main/java/bio/knowledge/server/blackboard/BeaconCall.java
@@ -1,0 +1,59 @@
+package bio.knowledge.server.blackboard;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+/**
+ * Wraps the CompletableFuture that is running the Supplier that
+ * harvests data from the beacons. It also has fields for keeping
+ * track of the progress of that Supplier.
+ *
+ * @param <T>
+ */
+public class BeaconCall<T> {
+	/**
+	 * A supplier interface that has some extra methods for reporting
+	 * the number of discovered and processed items
+	 * @param <S>
+	 */
+	public interface ReportableSupplier<S> extends Supplier<S> {
+		public Integer reportProcessed();
+		public Integer reportDiscovered();
+	}
+	
+	private final CompletableFuture<T> future;
+	private final ReportableSupplier<T> supplier;
+	
+	public BeaconCall(ReportableSupplier<T> supplier) {
+		this.supplier = supplier;
+		this.future = CompletableFuture.supplyAsync(supplier);
+	}
+	
+	public BeaconCall(ReportableSupplier<T> supplier, Executor executor) {
+		this.supplier = supplier;
+		this.future = CompletableFuture.supplyAsync(supplier, executor);
+	}
+	
+	public CompletableFuture<T> future() {
+		return this.future;
+	}
+	
+	public Integer processed() {
+		return this.supplier.reportProcessed();
+	}
+	
+	public Integer discovered() {
+		return this.supplier.reportDiscovered();
+	}
+	
+	public boolean isDone() {
+		return this.future.isDone();
+	}
+	
+	public T get() throws InterruptedException, ExecutionException {
+		return this.future.get();
+	}
+
+}

--- a/server/src/main/java/bio/knowledge/server/blackboard/CliquesQuery.java
+++ b/server/src/main/java/bio/knowledge/server/blackboard/CliquesQuery.java
@@ -29,10 +29,10 @@ package bio.knowledge.server.blackboard;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import bio.knowledge.aggregator.CliquesQueryInterface;
 import bio.knowledge.model.aggregator.neo4j.Neo4jConceptClique;
+import bio.knowledge.server.blackboard.BeaconCall.ReportableSupplier;
 import bio.knowledge.server.model.ServerClique;
 import bio.knowledge.server.model.ServerCliquesQuery;
 import bio.knowledge.server.model.ServerCliquesQueryBeaconStatus;
@@ -90,21 +90,34 @@ public class CliquesQuery extends
 	}
 
 	@Override
-	public Supplier<Integer> getQueryResultSupplier(Integer beacon) {
-		return () -> {
-			return queryBeaconForExactMatches();
+	public ReportableSupplier<Integer> getQueryResultSupplier(Integer beacon) {
+		return new ReportableSupplier<Integer>() {
+
+			@Override
+			public Integer get() {
+				List<String> identifiers = getKeywords();
+				
+				List<Neo4jConceptClique> results = getDatabaseInterface().harvestAndSaveData(identifiers);
+				
+				return results.size();
+			}
+
+			@Override
+			public Integer reportProcessed() {
+				return null;
+			}
+
+			@Override
+			public Integer reportDiscovered() {
+				return null;
+			}
+			
 		};
 	}
 	
-	private Integer queryBeaconForExactMatches() {
-		List<String> identifiers   = getKeywords();
-		
-		CliquesDatabaseInterface dbi = 
-				(CliquesDatabaseInterface)getDatabaseInterface();
-		
-		List<Neo4jConceptClique> results = dbi.harvestAndSaveData(identifiers);
-		
-		return results.size();
+	@Override
+	public CliquesDatabaseInterface getDatabaseInterface() {
+		return (CliquesDatabaseInterface) super.getDatabaseInterface();
 	}
 
 	@Override

--- a/server/src/main/java/bio/knowledge/server/blackboard/ConceptsQuery.java
+++ b/server/src/main/java/bio/knowledge/server/blackboard/ConceptsQuery.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
 
 import bio.knowledge.aggregator.ConceptsQueryInterface;
 import bio.knowledge.client.model.BeaconConcept;
+import bio.knowledge.server.blackboard.BeaconCall.ReportableSupplier;
 import bio.knowledge.server.model.ServerConcept;
 import bio.knowledge.server.model.ServerConceptsQuery;
 import bio.knowledge.server.model.ServerConceptsQueryBeaconStatus;
@@ -44,14 +45,7 @@ import bio.knowledge.server.model.ServerConceptsQueryStatus;
  * @author richard
  *
  */
-public class ConceptsQuery 
-			extends AbstractQuery<
-						ConceptsQueryInterface,
-						BeaconConcept,
-						ServerConcept
-					> 
-			implements  ConceptsQueryInterface
-{
+public class ConceptsQuery extends AbstractQuery<ConceptsQueryInterface, BeaconConcept, ServerConcept> implements  ConceptsQueryInterface {
 	
 	private final ServerConceptsQuery query;
 	private final ServerConceptsQueryStatus status;
@@ -213,39 +207,8 @@ public class ConceptsQuery
 		
 		return results;
 	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see bio.knowledge.server.blackboard.AbstractQuery#getQueryResultSupplier(java.lang.Integer)
-	 */
-	@Override
-	public Supplier<Integer> getQueryResultSupplier(Integer beaconId) {
-		return () -> {
-			try {
-				return queryBeaconForConcepts(beaconId);
-				
-			} catch (Exception e) {
-				getQueryTracker().removeBeaconHarvested(beaconId);
-				
-				throw e;
-			}
-		};
-	}
 	
-	/*
-	 * This method will access the given beacon, 
-	 * in a blocking fashion, within the above 
-	 * asynchronoous ComputableFuture. Once the
-	 * beacon returns its data, this method also 
-	 * loads it into the database, then returns 
-	 * size of result list
-	 * 
-	 * @param conceptsQuery
-	 * @param beacon
-	 * @return
-	 */
-	private Integer queryBeaconForConcepts(Integer beacon) {
-
+	private List<BeaconConcept> getConcepts(Integer beaconId) {
 		BeaconHarvestService bhs = getHarvestService();
 		
 		List<String> categories = getConceptCategories();
@@ -253,21 +216,63 @@ public class ConceptsQuery
 		
 		categories = categories.isEmpty() ? null : categories;
 		
-		// Call Beacon
-		List<BeaconConcept> results = bhs.getKnowledgeBeaconService().getConcepts(
+		return bhs.getKnowledgeBeaconService().getConcepts(
 				keywords,
 				categories,
 				DEFAULT_BEACON_QUERY_SIZE,
-				beacon
+				beaconId
 		);
-		
-		// Load BeaconConcept results into the blackboard database
-		ConceptsDatabaseInterface dbi = 
-				(ConceptsDatabaseInterface)getDatabaseInterface();
-		
-		dbi.loadData(this,results,beacon);
-		
-		return results.size();
+	}
+	
+	@Override
+	public ConceptsDatabaseInterface getDatabaseInterface() {
+		return (ConceptsDatabaseInterface) super.getDatabaseInterface();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see bio.knowledge.server.blackboard.AbstractQuery#getQueryResultSupplier(java.lang.Integer)
+	 */
+	@Override
+	public ReportableSupplier<Integer> getQueryResultSupplier(Integer beaconId) {
+		return new ReportableSupplier<Integer>() {
+			private Integer processed = null;
+			private Integer discovered = null;
+			
+			public final Integer BATCH_SIZE = 10;
+
+			@Override
+			public Integer get() {
+				List<BeaconConcept> concepts = getConcepts(beaconId);
+				
+				this.discovered = concepts.size();
+				
+				List<List<BeaconConcept>> batches = Utilities.buildBatches(concepts, BATCH_SIZE);
+				
+				for (List<BeaconConcept> batch : batches) {
+					getDatabaseInterface().loadData(ConceptsQuery.this, batch, beaconId);
+					
+					if (processed == null) {
+						processed = BATCH_SIZE;
+					} else {
+						processed += BATCH_SIZE;
+					}
+				}
+				
+				return concepts.size();
+			}
+
+			@Override
+			public Integer reportProcessed() {
+				return this.processed;
+			}
+
+			@Override
+			public Integer reportDiscovered() {
+				return this.discovered;
+			}
+			
+		};
 	}
 
 }

--- a/server/src/main/java/bio/knowledge/server/blackboard/CoreDatabaseInterface.java
+++ b/server/src/main/java/bio/knowledge/server/blackboard/CoreDatabaseInterface.java
@@ -67,9 +67,8 @@ public abstract class CoreDatabaseInterface<Q,B,S> implements DatabaseInterface<
 		List<Integer> queryBeacons = query.getQueryBeacons();
 		
 		// Initialize BeaconCallMap catalog with all QueryBeacons as keys
-		Map< Integer, CompletableFuture<Integer>> beaconCallMap = query.getBeaconCallMap();
-		for(Integer beacon: queryBeacons) {
-			beaconCallMap.put(beacon, null);
+		for(Integer beaconId: queryBeacons) {
+			query.clearBeaconCall(beaconId);
 		}
 		
 		List<Integer> beaconsToHarvest = new ArrayList<Integer>();

--- a/server/src/main/java/bio/knowledge/server/blackboard/StatementsDatabaseInterface.java
+++ b/server/src/main/java/bio/knowledge/server/blackboard/StatementsDatabaseInterface.java
@@ -296,7 +296,7 @@ public class StatementsDatabaseInterface
 				  				
 		int pageNumber = statementQuery.getPageNumber();
 		int pageSize   = statementQuery.getPageSize();
-		
+
 		List<Neo4jStatement> results = statementRepository.getQueryResults(
 				queryString,
 				beacons,
@@ -306,9 +306,6 @@ public class StatementsDatabaseInterface
 
 		List<ServerStatement> serverStatements = new ArrayList<ServerStatement>();
 		for (Neo4jStatement statement : results) {
-
-//			Neo4jGeneralStatement statement = (Neo4jGeneralStatement) result.get("statement");
-
 			Neo4jConcept neo4jSubject = statement.getSubject();
 			ServerStatementSubject serverSubject = new ServerStatementSubject();
 			

--- a/server/src/main/java/bio/knowledge/server/blackboard/StatementsQuery.java
+++ b/server/src/main/java/bio/knowledge/server/blackboard/StatementsQuery.java
@@ -27,13 +27,14 @@
  */
 package bio.knowledge.server.blackboard;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import bio.knowledge.aggregator.StatementsQueryInterface;
 import bio.knowledge.client.model.BeaconStatement;
 import bio.knowledge.model.aggregator.neo4j.Neo4jConceptClique;
+import bio.knowledge.server.blackboard.BeaconCall.ReportableSupplier;
 import bio.knowledge.server.controller.ExactMatchesHandler;
 import bio.knowledge.server.model.ServerStatement;
 import bio.knowledge.server.model.ServerStatementsQuery;
@@ -190,38 +191,7 @@ public class StatementsQuery
 		return results;
 	}
 	
-
-	/*
-	 * (non-Javadoc)
-	 * @see bio.knowledge.server.blackboard.AbstractQuery#getQueryResultSupplier(java.lang.Integer)
-	 */
-	@Override
-	public Supplier<Integer> getQueryResultSupplier(Integer beaconId) {
-		return ()-> {
-			try {
-				return queryBeaconForStatements(beaconId);
-				
-			} catch (Exception e) {
-				getQueryTracker().removeBeaconHarvested(beaconId);
-				
-				throw e;
-			}
-		};
-	}
-	
-	/*
-	 * This method will access the given beacon, 
-	 * in a blocking fashion, within the above 
-	 * asynchronoous ComputableFuture. Once the
-	 * beacon returns its data, this method also 
-	 * loads it into the database, then returns 
-	 * the list(?).
-	 * 
-	 * @param beacon
-	 * @return
-	 */
-	private Integer queryBeaconForStatements(Integer beacon) {
-		
+	private List<BeaconStatement> getStatements(Integer beaconId) {
 		BeaconHarvestService bhs = getHarvestService() ;
 		ExactMatchesHandler emh = bhs.getExactMatchesHandler();
 		
@@ -255,9 +225,7 @@ public class StatementsQuery
 		List<String> categories = getConceptCategories();
 		categories = categories.isEmpty() ? null : categories;
 				
-		// Call Beacon
-		List<BeaconStatement> results =
-				bhs.getKnowledgeBeaconService().
+		return bhs.getKnowledgeBeaconService().
 					getStatements(
 						sourceClique,
 						null,
@@ -266,18 +234,58 @@ public class StatementsQuery
 						keywords,
 						categories,
 						DEFAULT_BEACON_QUERY_SIZE,
-						beacon
+						beaconId
 					);
-	
-		// Load BeaconStatement results into the blackboard database
-		StatementsDatabaseInterface dbi = 
-				(StatementsDatabaseInterface)getDatabaseInterface();
-		
-		dbi.loadData(this,results,beacon);
+	}
 
-		return results.size();
+	/*
+	 * (non-Javadoc)
+	 * @see bio.knowledge.server.blackboard.AbstractQuery#getQueryResultSupplier(java.lang.Integer)
+	 */
+	@Override
+	public ReportableSupplier<Integer> getQueryResultSupplier(Integer beaconId) {
+		return new ReportableSupplier<Integer>() {
+			private Integer processed = null;
+			private Integer discovered = null;
+			
+			private final Integer BATCH_SIZE = 10;
+
+			@Override
+			public Integer get() {
+				List<BeaconStatement> statements = getStatements(beaconId);
+				
+				this.discovered = statements.size();
+				
+				List<List<BeaconStatement>> batches = Utilities.buildBatches(statements, BATCH_SIZE);
+
+				for (List<BeaconStatement> batch : batches) {
+					getDatabaseInterface().loadData(StatementsQuery.this, batch, beaconId);
+					
+					if (processed == null) {
+						this.processed = BATCH_SIZE;
+					} else {
+						this.processed += BATCH_SIZE;
+					}
+				}
+
+				return statements.size();
+			}
+
+			@Override
+			public Integer reportProcessed() {
+				return processed;
+			}
+
+			@Override
+			public Integer reportDiscovered() {
+				return discovered;
+			}
+			
+		};
 	}
 	
-
+	protected StatementsDatabaseInterface getDatabaseInterface() {
+		return (StatementsDatabaseInterface) super.getDatabaseInterface();
+	}
 
 }

--- a/server/src/main/java/bio/knowledge/server/blackboard/Utilities.java
+++ b/server/src/main/java/bio/knowledge/server/blackboard/Utilities.java
@@ -1,0 +1,30 @@
+package bio.knowledge.server.blackboard;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.collections.ListUtils;
+
+public final class Utilities {
+	private Utilities() {
+		
+	}
+	
+	/**
+	 * Converts a list into a list of sublists, each sublist being a batch of the
+	 * original
+	 * 
+	 * @param list
+	 * @param batchSize
+	 * @return
+	 */
+	public static <T> List<List<T>> buildBatches(List<T> list, int batchSize) {
+		List<List<T>> batches = new ArrayList<List<T>>();
+		
+		for (int i = 0; i < list.size(); i += batchSize) {
+			batches.add(list.subList(i, Math.min(i + batchSize, list.size())));
+		}
+		
+		return batches;
+	}
+}


### PR DESCRIPTION
- Increased read timeout (now read timeout is set along with connection timeout). Sometimes beacons were returning in a reasonable amount of time, but a timeout error was still being thrown because the response was too big to read in the default amount of time. This doesn't appear to be happening anymore.

- Added discovered and processed counts to the concept and statement status endpoints. The discovered count is set the moment the beacon responds.
- Now processing (building cliques and saving to the database) beacon responses in batches. The processed count will go up by the batch size each time a batch is completed, which is set to 10 by default.
- I ended up keeping the original count because it's useful for cases when the status is 201.

Example of output:
```
{
   "queryId":"ZAxp8UHR7vd5hwVvSB0k",
   "status":[
      {
         "beacon":1,
         "status":200,
         "discovered":0,
         "processed":null,
         "count":0
      },
      {
         "beacon":2,
         "status":102,
         "discovered":61,
         "processed":null,
         "count":null
      },
      {
         "beacon":3,
         "status":102,
         "discovered":160,
         "processed":60,
         "count":null
      },
      {
         "beacon":4,
         "status":200,
         "discovered":24,
         "processed":24,
         "count":24
      }
   ]
}
```